### PR TITLE
Adds references to W3C in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Verifiable claims in the holochain world, i.e. "Who said what about/to whom"
 
 ## Context
 
-Cryptographically verifiable claims are quite usefull for a number of scenarios, see: Wiki.
+Cryptographically verifiable claims are quite usefull for a number of scenarios, see: [W3C Technical Report](https://www.w3.org/TR/vc-use-cases/).
 
 Interestingly, every entry committe by an agent in a holochain application can be used as a veriable claim,
 because Holochain keeps track of the signed headers of every entry which include the entry hash. Holochain


### PR DESCRIPTION
This updates the README file with a link to W3C article on the use cases of Verifiable Claims: https://www.w3.org/TR/vc-use-cases/

@zippy it seems you left a placeholder for a Wiki? Was there a particular wiki page that you had in mind or the W3C technical report suffice?